### PR TITLE
Fix old os.loadAPI files to use require

### DIFF
--- a/energy_core_utils.lua
+++ b/energy_core_utils.lua
@@ -10,6 +10,8 @@ Includes setup, error handling, and energy core status checks.
 
 local config = require("config").energyCore
 
+local energy_core_utils = {}
+
 -- Peripherals
 local monitor
 local energyCore
@@ -33,14 +35,14 @@ end
 validatePeripherals()
 
 -- Function to log errors
-function logError(err)
+function energy_core_utils.logError(err)
     local logFile = fs.open(config.logsFile, "a")
     logFile.writeLine(os.date() .. ": " .. err)
     logFile.close()
 end
 
 -- Function to draw text on the monitor
-function drawText(x, y, text, textColor, bgColor)
+function energy_core_utils.drawText(x, y, text, textColor, bgColor)
     monitor.setCursorPos(x, y)
     monitor.setTextColor(textColor)
     monitor.setBackgroundColor(bgColor)
@@ -48,7 +50,7 @@ function drawText(x, y, text, textColor, bgColor)
 end
 
 -- Function to update the monitor with energy core status
-function updateMonitor()
+function energy_core_utils.updateMonitor()
     monitor.clear()
     local energyStored = energyCore.getEnergyStored()
     local maxEnergyStored = energyCore.getMaxEnergyStored()
@@ -61,7 +63,7 @@ function updateMonitor()
 end
 
 -- Function to log energy core statistics
-function logEnergyCoreStats()
+function energy_core_utils.logEnergyCoreStats()
     local logFile = fs.open("energy_core_stats.log", "a")
     local energyStored = energyCore.getEnergyStored()
     local maxEnergyStored = energyCore.getMaxEnergyStored()
@@ -71,7 +73,7 @@ function logEnergyCoreStats()
 end
 
 -- Function to handle click events on the monitor
-function clickListener()
+function energy_core_utils.clickListener()
     while true do
         local event, side, xPos, yPos = os.pullEvent("monitor_touch")
         if xPos >= 2 and xPos <= 9 and yPos >= 16 and yPos <= 18 then
@@ -81,3 +83,5 @@ function clickListener()
         end
     end
 end
+
+return energy_core_utils

--- a/main_control.lua
+++ b/main_control.lua
@@ -24,14 +24,14 @@ To save configuration changes, edit the `config.lua` file and then restart the s
 ]]
 
 -- Import required libraries and scripts
-os.loadAPI("reac_utils")
-os.loadAPI("monitor_utils")
-os.loadAPI("stat_utils")
-os.loadAPI("energy_core_utils")
+local reac_utils = require("reac_utils")
+local monitor_utils = require("monitor_utils")
+local stat_utils = require("stat_utils")
+local energy_core_utils = require("energy_core_utils")
 local config = require("config")
 
 -- Main loop
-function mainLoop()
+local function mainLoop()
     while true do
         reac_utils.checkReactorStatus()
 
@@ -78,7 +78,7 @@ function mainLoop()
 end
 
 -- Main entry point
-function main()
+local function main()
     reac_utils.setup()
     if reac_utils.mon == nil then
         mainLoop()

--- a/monitor_utils.lua
+++ b/monitor_utils.lua
@@ -10,13 +10,15 @@ Includes drawing elements on the monitor and handling click events.
 
 local config = require("config").energyCore
 
+local monitor_utils = {}
+
 -- Function to setup monitor
-function setupMonitor()
+function monitor_utils.setupMonitor()
     monitor.setTextScale(config.monitorScale)
 end
 
 -- Function to draw text on the monitor
-function drawText(x, y, text, textColor, bgColor)
+function monitor_utils.drawText(x, y, text, textColor, bgColor)
     monitor.setCursorPos(x, y)
     monitor.setTextColor(textColor)
     monitor.setBackgroundColor(bgColor)
@@ -24,14 +26,14 @@ function drawText(x, y, text, textColor, bgColor)
 end
 
 -- Function to clear the monitor
-function clearMonitor()
+function monitor_utils.clearMonitor()
     monitor.setBackgroundColor(colors.black)
     monitor.clear()
     monitor.setCursorPos(1, 1)
 end
 
 -- Function to draw a box on the monitor
-function drawBox(xMin, xMax, yMin, yMax, title)
+function monitor_utils.drawBox(xMin, xMax, yMin, yMax, title)
     monitor.setBackgroundColor(colors.gray)
     for xPos = xMin, xMax do
         monitor.setCursorPos(xPos, yMin)
@@ -53,7 +55,7 @@ function drawBox(xMin, xMax, yMin, yMax, title)
 end
 
 -- Function to draw a button on the monitor
-function drawButton(xMin, xMax, yMin, yMax, text1, text2, bColor)
+function monitor_utils.drawButton(xMin, xMax, yMin, yMax, text1, text2, bColor)
     monitor.setBackgroundColor(bColor)
     for yPos = yMin, yMax do
         for xPos = xMin, xMax do
@@ -70,7 +72,7 @@ function drawButton(xMin, xMax, yMin, yMax, text1, text2, bColor)
 end
 
 -- Function to handle click events on the monitor
-function clickListener()
+function monitor_utils.clickListener()
     while true do
         local event, side, xPos, yPos = os.pullEvent("monitor_touch")
         if xPos >= 2 and xPos <= 9 and yPos >= 16 and yPos <= 18 then
@@ -80,3 +82,5 @@ function clickListener()
         end
     end
 end
+
+return monitor_utils

--- a/reac_utils.lua
+++ b/reac_utils.lua
@@ -10,6 +10,8 @@ Includes setup, error handling, and reactor status checks.
 
 local config = require("config").reactor
 
+local reac_utils = {}
+
 -- Peripherals
 local reactor
 local gateIn
@@ -49,7 +51,7 @@ local function validatePeripherals()
 end
 
 -- Function to setup peripherals
-function setupPeripherals()
+function reac_utils.setupPeripherals()
     validatePeripherals() -- Updated to include validation
     gateIn.setOverrideEnabled(true)
     gateIn.setFlowOverride(0)
@@ -59,7 +61,7 @@ function setupPeripherals()
 end
 
 -- Function to get reactor status
-function getReactorStatus()
+function reac_utils.getReactorStatus()
     local success, status = pcall(function()
         return reactor.getReactorInfo().status
     end)
@@ -71,7 +73,7 @@ function getReactorStatus()
 end
 
 -- Function to get reactor temperature
-function getTemperature()
+function reac_utils.getTemperature()
     local success, temp = pcall(function()
         return reactor.getReactorInfo().temperature
     end)
@@ -83,7 +85,7 @@ function getTemperature()
 end
 
 -- Function to get reactor field strength
-function getFieldStrength()
+function reac_utils.getFieldStrength()
     local success, fieldStrength = pcall(function()
         return reactor.getReactorInfo().fieldStrength
     end)
@@ -95,7 +97,7 @@ function getFieldStrength()
 end
 
 -- Function to get reactor energy saturation
-function getEnergySaturation()
+function reac_utils.getEnergySaturation()
     local success, energySaturation = pcall(function()
         return reactor.getReactorInfo().energySaturation
     end)
@@ -107,7 +109,7 @@ function getEnergySaturation()
 end
 
 -- Function to set flux gate flow rate
-function setFluxGateFlowRate(channel, flowRate)
+function reac_utils.setFluxGateFlowRate(channel, flowRate)
     local success, result = pcall(function()
         channel.setSignalLowFlow(flowRate)
     end)
@@ -117,7 +119,7 @@ function setFluxGateFlowRate(channel, flowRate)
 end
 
 -- Function to perform fail-safe shutdown
-function failSafeShutdown()
+function reac_utils.failSafeShutdown()
     pcall(function()
         reactor.stopReactor()
         setFluxGateFlowRate(gateIn, config.shutDownField * 1.2)
@@ -126,7 +128,7 @@ function failSafeShutdown()
 end
 
 -- Setup function
-function setup()
+function reac_utils.setup()
     term.clear()
     print("Starting program...")
     setupPeripherals()
@@ -134,7 +136,7 @@ function setup()
 end
 
 -- Function to check reactor status
-function checkReactorStatus()
+function reac_utils.checkReactorStatus()
     local success, reactorInfo = pcall(function()
         return reactor.getReactorInfo()
     end)
@@ -149,7 +151,7 @@ function checkReactorStatus()
 end
 
 -- Function to determine if reactor is in emergency state
-function isEmergency()
+function reac_utils.isEmergency()
     currentEmergency = config.safeMode and info.temperature >= 2000.0 and 
         (info.status == "running" or info.status == "online" or info.status == "stopping") and 
         (info.temperature > config.defaultTemp + config.maxOvershoot or currentField < 0.004 or currentFuel < config.minFuel)
@@ -157,7 +159,7 @@ function isEmergency()
 end
 
 -- Function to adjust reactor temperature and field
-function adjustReactorTempAndField()
+function reac_utils.adjustReactorTempAndField()
     local temp = getTemperature()
     local tempInc = math.sqrt(config.defaultTemp - temp) / 2.0
     local newOutflow = math.min(config.maxOutflow, info.maxEnergySaturation * tempInc / 100)
@@ -174,7 +176,7 @@ function adjustReactorTempAndField()
 end
 
 -- Function to handle reactor stopping
-function handleReactorStopping()
+function reac_utils.handleReactorStopping()
     if currentField > config.shutDownField then
         setFluxGateFlowRate(gateIn, calcInflow(config.shutDownField, info.fieldDrainRate))
     else
@@ -189,7 +191,7 @@ function handleReactorStopping()
 end
 
 -- Function to update flux gates
-function updateFluxGates()
+function reac_utils.updateFluxGates()
     local newInflow = 0.0
     local newOutflow = 0.0
 
@@ -217,3 +219,5 @@ function updateFluxGates()
     setFluxGateFlowRate(gateIn, math.floor(newInflow))
     setFluxGateFlowRate(gateOut, math.floor(newOutflow * config.outputMultiplier))
 end
+
+return reac_utils

--- a/stat_utils.lua
+++ b/stat_utils.lua
@@ -10,6 +10,8 @@ Includes logging reactor statistics and generating reports.
 
 local config = require("config").energyCore
 
+local stat_utils = {}
+
 -- Peripherals
 local energyCore
 
@@ -23,7 +25,7 @@ end
 validatePeripherals()
 
 -- Function to log errors
-function logError(err)
+function stat_utils.logError(err)
     local logFile = fs.open(config.logsFile, "a")
     if logFile then
         logFile.writeLine(os.date() .. ": " .. err)
@@ -34,7 +36,7 @@ function logError(err)
 end
 
 -- Function to log reactor statistics
-function logReactorStats(reactor)
+function stat_utils.logReactorStats(reactor)
     local logFile = fs.open("reactor_stats.log", "a")
     if logFile then
         local info = reactor.getReactorInfo()
@@ -46,7 +48,7 @@ function logReactorStats(reactor)
 end
 
 -- Function to log energy core statistics
-function logEnergyCoreStats(inputRate, outputRate)
+function stat_utils.logEnergyCoreStats(inputRate, outputRate)
     local logFile = fs.open("energy_core_stats.log", "a")
     if logFile then
         local energyStored = energyCore.getEnergyStored()
@@ -58,3 +60,5 @@ function logEnergyCoreStats(inputRate, outputRate)
         print("Failed to open energy core statistics log file.")
     end
 end
+
+return stat_utils


### PR DESCRIPTION
This PR fixes usage of the deprecated `os.loadAPI` function to modern `require` practices, which reduces global bloat and fixes path resolution.

Fixes #3